### PR TITLE
Update to v1.0.3(1.12.2Forge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### [1.12.2-1.0.3](https://github.com/KatatsumuriPan/BetterLineBreak/releases/tag/1.12.2-1.0.3) - 2024-01-31
+
+- Fix not break between non-ASCII and ASCII in PHRASE mode.
+
 ### [1.12.2-1.0.2](https://github.com/KatatsumuriPan/BetterLineBreak/releases/tag/1.12.2-1.0.2) - 2024-01-20
 
 - Fix incorrect char widths with using Optifine and Smooth Font.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,13 +7,13 @@ modGroup = kpan.b_line_break
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 1.0.2
+modVersion = 1.0.3
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
-includeMCVersionJar = true
+includeMCVersionJar = false
 
 # The name of your jar when you produce builds, not including any versioning info
-modArchivesBaseName = BetterLineBreak
+modArchivesBaseName = BetterLineBreak-1.12.2(Forge)
 
 # Will update your build.gradle automatically whenever an update is available
 autoUpdateBuildScript = false

--- a/src/main/java/kpan/b_line_break/LineBreakingUtil.java
+++ b/src/main/java/kpan/b_line_break/LineBreakingUtil.java
@@ -273,7 +273,11 @@ public class LineBreakingUtil {
 					return false;
 				if (isStartBracket(prevChar))
 					return false;
-				return breakIndices.contains(index);
+				if (breakIndices.contains(index))
+					return true;
+				if (!isNormalAsciiLetter(prevChar) && isNormalAsciiLetter(c))
+					return true;
+				return false;
 			default:
 				throw new AssertionError();
 		}


### PR DESCRIPTION

- Fix not break between non-ASCII and ASCII in PHRASE mode.
