### PR TITLE
Update to v1.0.1(1.14.4Fabric)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### [1.14.4-fabric-1.0.1](https://github.com/KatatsumuriPan/BetterLineBreak/releases/tag/1.14.4-fabric-1.0.1) - 2024-01-31
+
+- Fix not break between non-ASCII and ASCII in PHRASE mode.
+
 ### [1.14.4-fabric-1.0.0](https://github.com/KatatsumuriPan/BetterLineBreak/releases/tag/1.14.4-fabric-1.0.0) - 2024-01-15
 
 - First release.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
-
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.14.4
 yarn_mappings=1.14.4+build.18
 loader_version=0.15.3
-
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=kpan.b_line_break
 archives_base_name=BetterLineBreak-1.14.4(Fabric)
-
 # Dependencies
 fabric_version=0.28.5+1.14

--- a/src/main/java/kpan/b_line_break/LineBreakingUtil.java
+++ b/src/main/java/kpan/b_line_break/LineBreakingUtil.java
@@ -276,7 +276,9 @@ public class LineBreakingUtil {
 					return false;
 				if (isStartBracket(prevChar))
 					return false;
-				return breakIndices.contains(index);
+				if (!isNormalAsciiLetter(prevChar) && isNormalAsciiLetter(c))
+					return true;
+				return false;
 			default:
 				throw new AssertionError();
 		}


### PR DESCRIPTION

- Fix not break between non-ASCII and ASCII in PHRASE mode.
