### PR TITLE
Update to v1.0.2(1.19.4Fabric)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### [1.19.4-fabric-1.0.2](https://github.com/KatatsumuriPan/BetterLineBreak/releases/tag/1.19.4-fabric-1.0.2) - 2024-01-31
+
+- Fix freezing bug.
+- Fix not break between non-ASCII and ASCII in PHRASE mode.
+
 ### [1.19.4-fabric-1.0.1](https://github.com/KatatsumuriPan/BetterLineBreak/releases/tag/1.19.4-fabric-1.0.1) - 2024-01-26
 
 - Fix \n bug.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.19.4+build.2
 loader_version=0.15.3
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=kpan.b_line_break
 archives_base_name=BetterLineBreak-1.19.4(Fabric)
 

--- a/src/main/java/kpan/b_line_break/LineBreakingUtil.java
+++ b/src/main/java/kpan/b_line_break/LineBreakingUtil.java
@@ -1,6 +1,6 @@
 package kpan.b_line_break;
 
-import com.google.budoux.Parser;
+import kpan.b_line_break.budoux.Parser;
 import com.google.common.collect.Lists;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;

--- a/src/main/java/kpan/b_line_break/LineBreakingUtil.java
+++ b/src/main/java/kpan/b_line_break/LineBreakingUtil.java
@@ -386,7 +386,7 @@ public class LineBreakingUtil {
 						break;
 					}
 				} else {
-					if (c == ' ' || i > 0 && canBreak(text.charAt(i), c, i, breakIndices)) {
+					if (c == ' ' || i > startIndex && canBreak(text.charAt(i), c, i, breakIndices)) {
 						lastBreak = i + offset;
 						lastBreakStyle = style;
 					}

--- a/src/main/java/kpan/b_line_break/LineBreakingUtil.java
+++ b/src/main/java/kpan/b_line_break/LineBreakingUtil.java
@@ -166,7 +166,9 @@ public class LineBreakingUtil {
 					return false;
 				if (isStartBracket(prevChar))
 					return false;
-				return breakIndices.contains(index);
+				if (!isNormalAsciiLetter(prevChar) && isNormalAsciiLetter(c))
+					return true;
+				return false;
 			}
 			default -> throw new AssertionError();
 		}

--- a/src/main/java/kpan/b_line_break/budoux/Parser.java
+++ b/src/main/java/kpan/b_line_break/budoux/Parser.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.budoux;
+package kpan.b_line_break.budoux;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;


### PR DESCRIPTION

- Fix freezing bug.
- Fix not break between non-ASCII and ASCII in PHRASE mode.
